### PR TITLE
Add error when search field is empty. Working as expected.

### DIFF
--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -5,7 +5,7 @@
     <!-- Not sure where this form will be sending the information too. Using /search as a place holder until logic/routes for implementing searches is concrete. -->
     <%= form_tag("/search", method: "get") do %>
       <%= label_tag(:search_form, "Search for:") %>
-      <%= text_field_tag(:search_form) %>
+      <%= text_field_tag(:search_form, nil, required: true) %>
       <%= submit_tag("Search") %>
     <% end %>
 </section>


### PR DESCRIPTION
Got the error to pop up when the search field is empty when submitting the search query. Take a look and test it out
